### PR TITLE
fix updatecache

### DIFF
--- a/upload/source/class/memory/memory_driver_file.php
+++ b/upload/source/class/memory/memory_driver_file.php
@@ -105,5 +105,8 @@ class memory_driver_file {
 		}
 		return $this->set($key, $old - $step);
 	}
+	public function exists($key) {
+	    return $this->get($key) !== FALSE;
+        }
 
 }


### PR DESCRIPTION
missing "exists" function result "updatecache" func will ignore to re-cache. 
Because "insert_syscache" will relay on " memory('exists', $cachename) "

![image](https://user-images.githubusercontent.com/73676126/227105203-f3662bf8-245f-4dcf-8e53-c08900b25375.png)
